### PR TITLE
Add UI capabilities for moving the "drilldown" marker around the data

### DIFF
--- a/src/index.jade
+++ b/src/index.jade
@@ -1,1 +1,3 @@
 div.mousebrain
+
+div.frame

--- a/src/index.jade
+++ b/src/index.jade
@@ -1,3 +1,3 @@
 div.mousebrain
 
-div.frame
+p Frame: #[span.frame]

--- a/src/index.js
+++ b/src/index.js
@@ -53,15 +53,20 @@ const vis = new Mousebrain(mbDiv, {
 });
 vis.render();
 
-const frameDiv = select('div.frame').node();
+const frameDiv = select('span.frame').node();
 const frameInput = new NumberInput(frameDiv, {
   frames: data.length
 });
 
-frameInput.on('frame', f => {
+const setFrame = f => {
+  frameInput.setValue(f);
+
   vis.setDrilldown(f);
   vis.render();
-});
+};
+
+frameInput.on('frame', setFrame);
+vis.epochVis.on('frame', setFrame);
 
 window.drill = (x) => {
   vis.setDrilldown(x);

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import Papa from 'papaparse';
 import { select } from 'd3-selection';
 
 import { Mousebrain } from './vis/Mousebrain';
+import { NumberInput } from './util/NumberInput';
 
 import dataRaw from '../data/small-data.csv';
 import epochRaw from '../data/small-epoch.csv';
@@ -51,3 +52,18 @@ const vis = new Mousebrain(mbDiv, {
   height: 540
 });
 vis.render();
+
+const frameDiv = select('div.frame').node();
+const frameInput = new NumberInput(frameDiv, {
+  frames: data.length
+});
+
+frameInput.on('frame', f => {
+  vis.setDrilldown(f);
+  vis.render();
+});
+
+window.drill = (x) => {
+  vis.setDrilldown(x);
+  vis.render();
+};

--- a/src/util/NumberInput/index.jade
+++ b/src/util/NumberInput/index.jade
@@ -1,0 +1,1 @@
+input(type="number" min="0" max=frames)

--- a/src/util/NumberInput/index.js
+++ b/src/util/NumberInput/index.js
@@ -13,13 +13,17 @@ export class NumberInput extends Events(VisComponent) {
         frames: options.frames
       }));
 
-    const input = select(this.el)
+    this.input = select(this.el)
       .select('input');
 
-    input.on('change', () => {
-      this.emit('frame', window.parseInt(input.property('value')));
+    this.input.on('change', () => {
+      this.emit('frame', window.parseInt(this.input.property('value')));
     });
   }
 
   render () {}
+
+  setValue (v) {
+    this.input.property('value', v);
+  }
 }

--- a/src/util/NumberInput/index.js
+++ b/src/util/NumberInput/index.js
@@ -1,0 +1,25 @@
+import { select } from 'd3-selection';
+import Events from 'candela/plugins/mixin/Events';
+import VisComponent from 'candela/VisComponent';
+
+import content from './index.jade';
+
+export class NumberInput extends Events(VisComponent) {
+  constructor (el, options) {
+    super(el);
+
+    select(this.el)
+      .html(content({
+        frames: options.frames
+      }));
+
+    const input = select(this.el)
+      .select('input');
+
+    input.on('change', () => {
+      this.emit('frame', window.parseInt(input.property('value')));
+    });
+  }
+
+  render () {}
+}

--- a/src/vis/Mousebrain/index.js
+++ b/src/vis/Mousebrain/index.js
@@ -1,6 +1,8 @@
-import { select } from 'd3-selection';
+import { event,
+         select } from 'd3-selection';
 import { scaleOrdinal } from 'd3-scale';
 import { schemeDark2 } from 'd3-scale-chromatic';
+import Events from 'candela/plugins/mixin/Events';
 import VisComponent from 'candela/VisComponent';
 import LineChart from 'candela/plugins/vega/LineChart';
 
@@ -10,7 +12,7 @@ function clamp (val, low, high) {
   return val < low ? low : (val > high ? high : val);
 }
 
-class EpochChart extends VisComponent {
+class EpochChart extends Events(VisComponent) {
   constructor (el, options) {
     super(el);
 
@@ -27,13 +29,24 @@ class EpochChart extends VisComponent {
 
     // Initialize drilldown marker.
     this.drilldown = 0;
+
+    // Intercept clicks on the epoch view.
+    select(this.el)
+      .on('click', () => {
+        const x = event.x - this.el.offsetLeft;
+        this.emit('frame', Math.floor(x / this.getWidth() * this.frames));
+      });
   }
 
-  render () {
-    const width = select(this.el)
+  getWidth () {
+    return select(this.el)
       .node()
       .getBoundingClientRect()
       .width;
+  }
+
+  render () {
+    const width = this.getWidth();
 
     let sel = select(this.el)
       .selectAll('div.frac')


### PR DESCRIPTION
There is now a combo box by which you can set the frame number.

You can also click directly on the epoch viewer; this will jump the drilldown marker to the point of the click, as well as update the combo box.